### PR TITLE
feat: header now transitions in after scrim

### DIFF
--- a/components/organisms/site-header/SiteHeader.vue
+++ b/components/organisms/site-header/SiteHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    :class="['site-header', { navIsHidden }, { navIsAtTop }]"
+    :class="['site-header', { navIsHidden: !headerIsVisible }, { navIsAtTop }]"
     @mouseenter="showNav"
   >
     <SiteHeaderNavigation
@@ -25,7 +25,7 @@ export default {
     return {
       activeItem: null,
       navIsAtTop: true,
-      navIsHidden: 0,
+      // navIsHidden: true,
       showScrollButton: false,
       highlightedIndex: null,
       linksPrimary: [
@@ -76,6 +76,9 @@ export default {
     },
     winHeight() {
       return this.$store.state.device.winHeight
+    },
+    headerIsVisible() {
+      return this.$store.state.headerIsVisible
     }
   },
   mounted() {
@@ -113,18 +116,18 @@ export default {
       const nearBottomOffset = 25
       const nearBottom = this.winHeight + y + nearBottomOffset >= this.docHeight
 
-      if (hasScrolledUp && this.navIsHidden) this.showNav()
-      if (hasScrolledDown && !this.navIsHidden) this.hideNav()
-      if (nearBottom && this.navIsHidden) this.showNav()
-      if (nearTop && this.navIsHidden) this.showNav()
+      if (hasScrolledUp && !this.headerIsVisible) this.showNav()
+      if (hasScrolledDown && this.headerIsVisible) this.hideNav()
+      if (nearBottom && !this.headerIsVisible) this.showNav()
+      if (nearTop && !this.headerIsVisible) this.showNav()
       this.navIsAtTop = nearTop
       this.showScrollButton = !nearTop
     },
     showNav() {
-      this.navIsHidden = 0
+      this.$store.commit('setHeaderVisibility', true)
     },
     hideNav() {
-      this.navIsHidden = 1
+      this.$store.commit('setHeaderVisibility', false)
     },
     updateActiveItem(val) {
       this.activeItem = val

--- a/components/templates/Scrim.vue
+++ b/components/templates/Scrim.vue
@@ -64,6 +64,8 @@ export default {
     leave(el, done) {
       if (this.hideAnimations) done()
 
+      let transOverCalled = false
+
       this.tl.to(this.$refs.scrim, {
         ease: 'Power4.easeInOut',
         duration: 1,
@@ -77,6 +79,14 @@ export default {
         //   //   stagger: 0.1
         //   // })
         // },
+        onUpdate: () => {
+          // waiting until the end took too long,
+          // this waits until animatino has hit 50%
+          if (!transOverCalled && this.tl.progress() >= 0.75) {
+            transOverCalled = true
+            this.$store.commit('setHeaderVisibility', true)
+          }
+        },
         onComplete: () => {
           this.$store.commit('setIsTransitioning', false)
           done()

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -22,7 +22,7 @@
 
     <SiteMenu class="site-menu" />
     <!-- <Debug /> -->
-    <!-- <Scrim /> -->
+    <Scrim />
   </div>
 </template>
 
@@ -31,15 +31,15 @@ import SiteHeader from '@/components/organisms/site-header/SiteHeader'
 import SiteFooter from '@/components/organisms/site-footer/SiteFooter'
 import SiteMenu from '@/components/organisms/site-menu/SiteMenu'
 // import Debug from '@/components/templates/Debug'
-// import Scrim from '@/components/templates/Scrim'
+import Scrim from '@/components/templates/Scrim'
 
 export default {
   components: {
     SiteHeader,
     SiteFooter,
-    SiteMenu
+    SiteMenu,
     // LazyTime
-    // Scrim
+    Scrim
     // Debug
   },
   computed: {

--- a/store/index.js
+++ b/store/index.js
@@ -7,6 +7,7 @@ export const state = () => ({
   layoutHasMounted: null,
   isTransitioning: null,
   activeNavigationRoute: null,
+  headerIsVisible: false,
   menuIsOpen: false,
   menuIsTransitioning: false,
   filterIsVisible: null,
@@ -28,6 +29,9 @@ export const mutations = {
   },
   setFilterVisibility(state, val) {
     state.filterIsVisible = val
+  },
+  setHeaderVisibility(state, val) {
+    state.headerIsVisible = val
   },
   setMenuVisibility(state, val) {
     state.menuIsOpen = val


### PR DESCRIPTION
# Header Transition after load

## Description

After the scrim animates, the header is then introduced. I also went ahead and registered the header's visibility within the global store for easy triggering throughout the app. To show/hide the header from now on, simple run: `this.$store.commit('setHeaderVisibility', {BOOLEAN})`.

## Type of change
- [x] 🎉 **New Feature** _(non-breaking change which adds functionality)_
